### PR TITLE
Get int

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS=-O2 -fPIC -Wall
+CFLAGS=-O2 -fPIC -Wall -Wno-attribute-alias
 LDFLAGS=-shared -nostdlib
 
 TARGET=libnvram.so libnvram_ioctl.so

--- a/nvram.c
+++ b/nvram.c
@@ -773,8 +773,6 @@ int nvram_unset(const char *key) {
 int nvram_safe_unset(const char *key) {
     // If we have a value for this key, unset it. Otherwise no-op
     // Always return E_SUCCESS(?)
-    char* ret = nvram_get(key);
-
     if (nvram_get_buf(key, temp, BUFFER_SIZE) == E_SUCCESS) {
       nvram_unset(key);
     }


### PR DESCRIPTION
I've seen some FWs store int as strings, then fail to read them with `nvram_get_int`.

This PR makes it so the `nvram_get_int` function will try decoding a value as ASCII to get an int, and if that fails, it will read the raw integer value from the file.


Old behavior:
```
nvram_get_buf: sw_mode
nvram_get_buf: Unable to open key: /firmadyne/libnvram/sw_mode! Set default value to ""
nvram_get_buf: sw_mode
nvram_get_buf: Unable to open key: /firmadyne/libnvram/sw_mode! Set default value to ""
nvram_set: sw_mode = "1"
nvram_get_buf: sw_mode
nvram_get_buf: 

[NVRAM] 7 sw_mode

nvram_get_buf: = "1"
nvram_get_int: sw_mode
nvram_get_int: Unable to read key: /firmadyne/libnvram/sw_mode!
nvram_get_buf: sw_mode
nvram_get_buf: 

[NVRAM] 7 sw_mode

nvram_get_buf: = "1"
nvram_get_int: sw_mode
nvram_get_int: Unable to read key: /firmadyne/libnvram/sw_mode!
```